### PR TITLE
Marked settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Settings for the [doT][dot] template engine.
 
 ### marked_settings
 
-Takes any [marked options](https://github.com/chjj/marked/tree/0d27d58f16e3aa478cbc89a9a304e592e2862c5a#options-1).
+Takes any [marked options][marked_options].
 
 ## Contributing
 
@@ -153,3 +153,4 @@ Previous versions as "grunt-stencil":
 [marked]: https://github.com/chjj/marked
 [grunt-zetzer]: https://github.com/brainshave/grunt-zetzer
 [broccoli-zetzer]: https://github.com/brainshave/broccoli-zetzer
+[marked_options]: https://github.com/chjj/marked/tree/0d27d58f16e3aa478cbc89a9a304e592e2862c5a#options-1

--- a/README.md
+++ b/README.md
@@ -115,6 +115,10 @@ line.
 
 Settings for the [doT][dot] template engine.
 
+### marked_settings
+
+Takes any [marked options](https://github.com/chjj/marked/tree/0d27d58f16e3aa478cbc89a9a304e592e2862c5a#options-1).
+
 ## Contributing
 
 Please make sure your changes follow the current style and all test

--- a/markdown.js
+++ b/markdown.js
@@ -12,19 +12,19 @@ module.exports = setup;
 var md = require("marked");
 
 function setup (config) {
-	var settings = config.marked_settings || {};
-	md.setOptions(settings);
+  var settings = config.marked_settings || {};
+  md.setOptions(settings);
 
-	return {
-	  applies_to: applies_to,
-	  compile: compile
-	};
+  return {
+    applies_to: applies_to,
+    compile: compile
+  };
 
-	function compile (src) {
-	  return md(src);
-	}
+  function compile (src) {
+    return md(src);
+  }
 
-	function applies_to (file_path) {
-	  return /\.md$|\.md\./.test(file_path);
-	}
+  function applies_to (file_path) {
+    return /\.md$|\.md\./.test(file_path);
+  }
 }

--- a/markdown.js
+++ b/markdown.js
@@ -7,17 +7,24 @@
  * input files that require this compiler
  */
 
-module.exports = {
-  applies_to: applies_to,
-  compile: compile
-};
+module.exports = setup;
 
 var md = require("marked");
 
-function compile (src) {
-  return md(src);
-}
+function setup (config) {
+	var settings = config.marked_settings || {};
+	md.setOptions(settings);
 
-function applies_to (file_path) {
-  return /\.md$|\.md\./.test(file_path);
+	return {
+	  applies_to: applies_to,
+	  compile: compile
+	};
+
+	function compile (src) {
+	  return md(src);
+	}
+
+	function applies_to (file_path) {
+	  return /\.md$|\.md\./.test(file_path);
+	}
 }

--- a/spec/markdown_spec.js
+++ b/spec/markdown_spec.js
@@ -5,13 +5,10 @@ var trim = require("./trim");
 
 describe("markdown_compiler", function () {
 
-  var markdown = require("../markdown");
+  var markdown_setup = require("../markdown");
   
-
-
-
   describe("applies_to", function () {
-    var compiler = markdown({});
+    var compiler = markdown_setup({});
     it("returns true for a markdown path", function () {
       expect(compiler.applies_to("file.md")).toEqual(true);
       expect(compiler.applies_to("file.dot.md.haml")).toEqual(true);
@@ -23,7 +20,7 @@ describe("markdown_compiler", function () {
   });
 
   describe("compile", function () {
-    var compiler = markdown({});
+    var compiler = markdown_setup({});
     it("compiles markdown", function () {
       var content = random.word();
       expect(trim(compiler.compile(content))).toEqual("<p>" + content + "</p>");
@@ -33,7 +30,7 @@ describe("markdown_compiler", function () {
   describe("setup", function(){
     it("renders markdown tables as html when gfm and tables are true", function(){
       var content = "\r\n\r\n| col1 | col2 |\r\n| ---- | ---- |\r\n| row2col1 | row2col2 |\r\n\r\n"
-      var compiler = markdown({marked_settings:{gfm:true, tables:true}});
+      var compiler = markdown_setup({marked_settings:{gfm:true, tables:true}});
       expect(trim(compiler.compile(content))).toMatch("<table");
     });
   });

--- a/spec/markdown_spec.js
+++ b/spec/markdown_spec.js
@@ -5,9 +5,13 @@ var trim = require("./trim");
 
 describe("markdown_compiler", function () {
 
-  var compiler = require("../markdown");
+  var markdown = require("../markdown");
+  
+
+
 
   describe("applies_to", function () {
+    var compiler = markdown({});
     it("returns true for a markdown path", function () {
       expect(compiler.applies_to("file.md")).toEqual(true);
       expect(compiler.applies_to("file.dot.md.haml")).toEqual(true);
@@ -19,9 +23,19 @@ describe("markdown_compiler", function () {
   });
 
   describe("compile", function () {
+    var compiler = markdown({});
     it("compiles markdown", function () {
       var content = random.word();
       expect(trim(compiler.compile(content))).toEqual("<p>" + content + "</p>");
     });
   });
+
+  describe("setup", function(){
+    it("renders markdown tables as html when gfm and tables are true", function(){
+      var content = "\r\n\r\n| col1 | col2 |\r\n| ---- | ---- |\r\n| row2col1 | row2col2 |\r\n\r\n"
+      var compiler = markdown({marked_settings:{gfm:true, tables:true}});
+      expect(trim(compiler.compile(content))).toMatch("<table");
+    });
+  });
+
 });

--- a/spec/markdown_spec.js
+++ b/spec/markdown_spec.js
@@ -28,11 +28,42 @@ describe("markdown_compiler", function () {
   });
 
   describe("setup", function(){
-    it("renders markdown tables as html when gfm and tables are true", function(){
+    it("does not render markdown tables as html when tables is false.", function(){
       var content = "\r\n\r\n| col1 | col2 |\r\n| ---- | ---- |\r\n| row2col1 | row2col2 |\r\n\r\n"
-      var compiler = markdown_setup({marked_settings:{gfm:true, tables:true}});
+      var compiler = markdown_setup({marked_settings:{tables:false}});
+      expect(trim(compiler.compile(content))).not.toMatch("<table");
+    });
+  });
+
+  describe("setup", function(){
+    it("renders markdown tables as html when tables is true", function(){
+      var content = "\r\n\r\n| col1 | col2 |\r\n| ---- | ---- |\r\n| row2col1 | row2col2 |\r\n\r\n"
+      var compiler = markdown_setup({marked_settings:{tables:true}});
       expect(trim(compiler.compile(content))).toMatch("<table");
     });
   });
 
+  describe("setup", function(){
+    it("renders markdown javascript code block as GFM codeblock when no marked_settings", function(){
+      var content = "\r\n\r\n```javascript\r\nvar foo = {bar:true};\r\n```\r\n"
+      var compiler = markdown_setup({});
+      expect(trim(compiler.compile(content))).toMatch("<code class=\"lang-javascript\">");
+    });
+  });
+
+  describe("setup", function(){
+    it("renders markdown javascript code block as GFM codeblock when gfm is true", function(){
+      var content = "\r\n\r\n```javascript\r\nvar foo = {bar:true};\r\n```\r\n"
+      var compiler = markdown_setup({marked_settings:{gfm:true}});
+      expect(trim(compiler.compile(content))).toMatch("<code class=\"lang-javascript\">");
+    });
+  });
+
+  describe("setup", function(){
+    it("renders markdown javascript code block as code tag when gfm is false", function(){
+      var content = "\r\n\r\n```javascript\r\nvar foo = {bar:true};\r\n```\r\n"
+      var compiler = markdown_setup({marked_settings:{gfm:false}});
+      expect(trim(compiler.compile(content))).toMatch("<code>");
+    });
+  });
 });


### PR DESCRIPTION
Fixes #1. Refactored markdown.js to accept `config.marked_settings` in setup. Added test for table markup.
